### PR TITLE
fix _compute_invoice_state method

### DIFF
--- a/multi_company_holding_invoicing/models/sale.py
+++ b/multi_company_holding_invoicing/models/sale.py
@@ -42,6 +42,11 @@ class SaleOrder(models.Model):
         # Note for perf issue the 'holding_invoice_id.state' is not set here
         # as a dependency. Indeed the dependency is manually triggered when
         # the holding_invoice is generated or the state is changed
+        # Note because the 'picking_ids' field is not stored,
+        # the 'picking_ids.state' is not set here as a dependency.
+        # Indeed, the dependency is automatically triggered when
+        # the state of picking is changed
+        # (see onchange_state method in stock.picking).
         for sale in self:
             if not sale.section_id.holding_company_id:
                 sale.invoice_state = 'none'

--- a/multi_company_holding_invoicing/models/sale.py
+++ b/multi_company_holding_invoicing/models/sale.py
@@ -20,26 +20,24 @@ class SaleOrder(models.Model):
         readonly=True,
         copy=False,
         store=True)
-
     holding_invoice_id = fields.Many2one(
         'account.invoice',
         string='Holding Invoice',
         copy=False,
         readonly=True)
-
     invoice_state = fields.Selection([
         ('none', 'Not Applicable'),
         ('not_ready', 'Not Ready'),
         ('invoiceable', 'Invoiceable'),
         ('pending', 'Pending'),
         ('invoiced', 'Invoiced'),
-        ], string='Invoice State',
+    ], string='Invoice State',
         copy=False,
         compute='_compute_invoice_state',
         store=True)
 
     @api.multi
-    @api.depends('shipped', 'section_id.holding_company_id')
+    @api.depends('picking_ids', 'section_id.holding_company_id')
     def _compute_invoice_state(self):
         # Note for perf issue the 'holding_invoice_id.state' is not set here
         # as a dependency. Indeed the dependency is manually triggered when
@@ -52,7 +50,9 @@ class SaleOrder(models.Model):
                     sale.invoice_state = 'invoiced'
                 else:
                     sale.invoice_state = 'pending'
-            elif sale.shipped:
+            elif (sale.picking_ids and
+                  not sale.picking_ids.filtered(
+                    lambda r: r.state not in ['done', 'cancel'])):
                 sale.invoice_state = 'invoiceable'
             else:
                 sale.invoice_state = 'not_ready'

--- a/multi_company_holding_invoicing/models/stock_picking.py
+++ b/multi_company_holding_invoicing/models/stock_picking.py
@@ -5,8 +5,12 @@
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
 
 
-from . import sales_team
-from . import sale
-from . import invoice
-from . import model
-from . import stock_picking
+from openerp import models, api
+
+
+class StockPicking(models.Model):
+    _inherit = 'stock.picking'
+
+    @api.onchange('state')
+    def onchange_state(self):
+        return self.env['sale.order']._compute_invoice_state()


### PR DESCRIPTION
The _compute_invoice_state method depended of 'shipped' computed field.
However, the 'shipped' field depends on the status of procurements but not on the status of pickings.
So, we had sales orders with invoiceable status when they were not delivered.